### PR TITLE
Fix usage of MovePlayerPacket, require latest API

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -3,7 +3,7 @@ version: "1.1"
 
 author: ChalkPE
 main: chalk\cameraman\Cameraman
-api: [1.12.0, 1.13.0, 2.0.0]
+api: [3.0.0-ALPHA5]
 
 website: http://chalk.pe
 description: An automatic motion control plugin for PocketMine-MP

--- a/src/chalk/cameraman/Cameraman.php
+++ b/src/chalk/cameraman/Cameraman.php
@@ -35,7 +35,7 @@ use pocketmine\event\player\PlayerQuitEvent;
 use pocketmine\event\server\DataPacketReceiveEvent;
 use pocketmine\level\Location;
 use pocketmine\math\Vector3;
-use pocketmine\network\protocol\MovePlayerPacket;
+use pocketmine\network\mcpe\protocol\MovePlayerPacket;
 use pocketmine\Player;
 use pocketmine\plugin\PluginBase;
 use pocketmine\utils\Config;
@@ -272,7 +272,7 @@ class Cameraman extends PluginBase implements Listener {
      */
     public static function sendMovePlayerPacket(Player $player){
         $packet = new MovePlayerPacket();
-        $packet->eid = 0;
+        $packet->eid = $player->getId();
         $packet->x = $player->getX();
         $packet->y = $player->getY();
         $packet->z = $player->getZ();


### PR DESCRIPTION
Update to work with latest API.
Tested and basic travelling works, nothing else tested.
It might work on some ealier 3.0.0 versions, but I didn’t have time to
test. Will not work on anything before 3.0.0 though, due to the eid
change.